### PR TITLE
CLI documentation added 

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,23 +165,295 @@ This toolkit is written for scientists across domains:
 * structural biologists studying phospho-binding domain specificity
 * any researcher wanting a **transparent, modifiable, modern** NetPhorest engine
 
-Everything runs with a single CLI:
+---
+
+## Install the package
+
+```
+pip install pynetphorest
+```
+
+## Command-line interface
+
+After installation, all functionality is available via the single entrypoint:
 
 ```bash
-app netphorest ...
-app crosstalk ...
-app evaluate ...
+pynetphorest [COMMAND] [SUBCOMMAND] [OPTIONS]
 ```
 
-and the Snakemake pipeline ties the whole ecosystem together.
+Top-level commands:
 
-```bash 
-snakemake -j 8 --config mode=netphorest  
-# or 
-snakemake -j 8 --config mode=crosstalk 
-# or 
-snakemake -j 8 --config mode=both
+* `netphorest` – kinase–substrate site prediction
+* `crosstalk` – PTM–PTM crosstalk modeling and evaluation
+
+You can always inspect help with:
+
+```bash
+pynetphorest --help
+pynetphorest netphorest --help
+pynetphorest crosstalk --help
 ```
+
+---
+
+### 1. NetPhorest: kinase–substrate prediction
+
+NetPhorest commands are grouped under:
+
+```bash
+pynetphorest netphorest [SUBCOMMAND] ...
+```
+
+Currently there is one subcommand: `fasta`.
+
+#### 1.1 `netphorest fasta`
+
+Run NetPhorest on a protein FASTA:
+
+```bash
+pynetphorest netphorest fasta FASTA \
+    [--atlas ATLAS] \
+    [--out TSV] \
+    [--causal] \
+    [--min-posterior P] \
+    [--sigmoid-clamp X]
+```
+
+**Positional argument**
+
+* `FASTA`
+  Input FASTA file with protein sequences (or `-` for stdin).
+
+**Options**
+
+* `--atlas ATLAS`
+  Path to a NetPhorest atlas (`.db`, `.sqlite`, `.json`).
+  If omitted, the bundled atlas is used (first `netphorest.db`, then `netphorest.json` inside the package).
+
+* `--out TSV`
+  Output TSV file. If not given, results are written to stdout.
+
+* `--causal`
+  Enable writer→reader “causal” linking mode (kinase recruits a binding-domain reader).
+
+* `--min-posterior P`
+  Only report sites with posterior probability ≥ `P`.
+  Use this to filter out low-confidence hits.
+
+* `--sigmoid-clamp X`
+  Absolute clamp on the logistic scoring term for numerical stability
+  (default `50.0`; set to `0` to disable clamping).
+
+---
+
+### 2. Crosstalk: PTM–PTM interaction modeling
+
+Crosstalk commands are grouped under:
+
+```bash
+pynetphorest crosstalk [SUBCOMMAND] ...
+```
+
+Available subcommands:
+
+* `train` – train a crosstalk classifier from PTMcode2 + NetPhorest features
+* `predict` – predict crosstalk on new FASTA sequences
+* `eval` – offline evaluation and plotting for a trained model
+* `model-thresh` – threshold sweep and metrics tables
+
+You can inspect them via:
+
+```bash
+pynetphorest crosstalk train --help
+pynetphorest crosstalk predict --help
+pynetphorest crosstalk eval --help
+pynetphorest crosstalk model-thresh --help
+```
+
+#### 2.1 `crosstalk train`
+
+Train a pairwise crosstalk model:
+
+```bash
+pynetphorest crosstalk train FASTA WITHIN_GZ BETWEEN_GZ \
+    [--atlas ATLAS] \
+    [--out PKL] \
+    [--window-size N] \
+    [--neg-ratio K]
+```
+
+**Positional arguments**
+
+* `FASTA`
+  FASTA file for sequence context (IDs must match PTMcode2).
+
+* `WITHIN_GZ`
+  PTMcode2 within-protein edges file (e.g. `within.gz`).
+
+* `BETWEEN_GZ`
+  PTMcode2 between-protein edges file (e.g. `between.gz`).
+
+**Options**
+
+* `--atlas ATLAS`
+  NetPhorest atlas path. If omitted, the bundled atlas is used.
+
+* `--out PKL`
+  Output model filename (default: `crosstalk_model.pkl`).
+
+* `--window-size N`
+  Peptide window size around each STY site (odd number, default: `9`).
+
+* `--neg-ratio, --negative-ratio K`
+  Number of negative edges per positive (default: `3`).
+
+Outputs (in the working directory):
+
+* `crosstalk_model.pkl` – trained classifier
+* `full_dataset.npz` – full feature matrix + labels
+* `eval_data.npz` – held-out test split
+* `edge_metadata.json` – JSON-lines metadata per edge
+
+---
+
+#### 2.2 `crosstalk predict`
+
+Predict functional crosstalk for a new FASTA:
+
+```bash
+pynetphorest crosstalk predict FASTA \
+    [--model PKL] \
+    [--atlas ATLAS] \
+    [--out TSV] \
+    [--thresh P] \
+    [--jobs N]
+```
+
+**Positional argument**
+
+* `FASTA`
+  Input FASTA whose STY sites you want to score.
+
+**Options**
+
+* `--model PKL`
+  Trained model file (default: `crosstalk_model.pkl`).
+
+* `--atlas ATLAS`
+  NetPhorest atlas path. If omitted, the bundled atlas is used.
+
+* `--out TSV`
+  Output predictions file (default: `crosstalk_predictions.tsv`).
+
+* `--thresh P`
+  Base probability threshold for reporting a pair (default: `0.8`).
+  Per-residue internal thresholds (S/S, Y/Y, mixed) still apply.
+
+* `--jobs, --n-jobs N`
+  Number of parallel processes (default: `-1`, use all cores).
+
+**Output columns**
+
+* `Protein`
+* `Site1` (e.g. `S123`)
+* `Site2` (e.g. `Y456`)
+* `Crosstalk_Prob`
+
+---
+
+#### 2.3 `crosstalk eval`
+
+Offline evaluation and plotting:
+
+```bash
+pynetphorest crosstalk eval \
+    --model PKL \
+    --eval-npz NPZ \
+    --dataset-npz NPZ \
+    [--predictions-tsv TSV] \
+    [--metadata JSONL] \
+    [--outdir DIR]
+```
+
+**Required options**
+
+* `--model PKL`
+  Trained model.
+
+* `--eval-npz NPZ`
+  `eval_data.npz` containing `X_test`, `y_test`, `w_test`.
+
+* `--dataset-npz NPZ`
+  `full_dataset.npz` containing the full dataset (`X`, `y`).
+
+**Optional**
+
+* `--predictions-tsv TSV`
+  Predictions TSV from `crosstalk predict` for additional summaries.
+
+* `--metadata JSONL`
+  `edge_metadata.json` or `.jsonl` with edge annotations.
+
+* `--outdir DIR`
+  Output directory for figures/tables (default: `eval_output`).
+
+Produces:
+
+* PR / ROC curves
+* Confusion matrix
+* Feature-group importance
+* rRCS summaries
+* Optional prediction summaries
+
+---
+
+#### 2.4 `crosstalk model-thresh`
+
+Threshold sweep and metrics:
+
+```bash
+pynetphorest crosstalk model-thresh \
+    [--model PKL] \
+    [--eval-npz NPZ] \
+    [--dataset-npz NPZ] \
+    [--metadata JSONL] \
+    [--min-th FLOAT] \
+    [--max-th FLOAT] \
+    [--step FLOAT] \
+    [--out-global TSV] \
+    [--out-residues TSV]
+```
+
+**Options**
+
+* `--model PKL`
+  Trained model (default: `crosstalk_model.pkl`).
+
+* `--eval-npz NPZ`
+  Eval split (default: `eval_data.npz`).
+
+* `--dataset-npz NPZ`
+  Full dataset (default: `full_dataset.npz`).
+
+* `--metadata JSONL`
+  Edge metadata (default: `edge_metadata.json`).
+
+* `--min-th FLOAT`
+  Minimum threshold (default: `0.10`).
+
+* `--max-th FLOAT`
+  Maximum threshold (default: `0.90`).
+
+* `--step FLOAT`
+  Threshold step size (default: `0.05`).
+
+* `--out-global TSV`
+  Optional TSV for global metrics.
+
+* `--out-residues TSV`
+  Optional TSV for residue-level metrics.
+
+Metrics include precision, recall, F1, MCC, and TP/FP/TN/FN counts across thresholds.
 
 ---
 


### PR DESCRIPTION
This pull request significantly expands and clarifies the documentation in `README.md` to provide a comprehensive guide for installing and using the `pynetphorest` toolkit. The updated documentation now includes detailed installation instructions, an overview of the command-line interface, and step-by-step usage examples for both the NetPhorest and Crosstalk modules, making it much easier for users to get started and understand the available features.

**Documentation improvements:**

* Added a dedicated installation section with `pip install` instructions for `pynetphorest`.
* Replaced the old CLI overview with a detailed explanation of the new unified `pynetphorest` command-line interface, including top-level commands and help instructions.

**Usage examples and command details:**

* Provided comprehensive usage examples and option explanations for NetPhorest kinase–substrate prediction, including subcommands and argument details.
* Added in-depth documentation for Crosstalk PTM–PTM interaction modeling, covering training, prediction, evaluation, and threshold analysis, with command syntax, argument descriptions, and output explanations.

**General structure and clarity:**

* Organized the documentation into clear thematic sections with markdown headings and separators for easier navigation and readability.